### PR TITLE
add skeleton for the xacro metamodel

### DIFF
--- a/de.fraunhofer.ipa.kinematics/model/xacro.ecore
+++ b/de.fraunhofer.ipa.kinematics/model/xacro.ecore
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="xacro" nsURI="http://www.ipa.fraunhofer.de/xacro" nsPrefix="xacro">
+  <eClassifiers xsi:type="ecore:EClass" name="Robot">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" lowerBound="1" eType="ecore:EDataType ../../org.eclipse.emf.ecore/model/Ecore.ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="parameter" upperBound="-1"
+        eType="#//Parameter"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="body" upperBound="-1" eType="#//Body"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Parameter">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="Name" lowerBound="1" eType="ecore:EDataType ../../org.eclipse.emf.ecore/model/Ecore.ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="Default" eType="ecore:EDataType ../../org.eclipse.emf.ecore/model/Ecore.ecore#//EString"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Body">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="transmission" upperBound="-1"
+        eType="ecore:EClass urdf.ecore#//Transmission" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="inertial" upperBound="-1"
+        eType="ecore:EClass urdf.ecore#//Inertial" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="robot" upperBound="-1"
+        eType="ecore:EClass urdf.ecore#//RobotType" containment="true"/>
+  </eClassifiers>
+</ecore:EPackage>

--- a/de.fraunhofer.ipa.kinematics/model/xacro.genmodel
+++ b/de.fraunhofer.ipa.kinematics/model/xacro.genmodel
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<genmodel:GenModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"
+    xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" modelDirectory="/de.fraunhofer.ipa.kinematics/src" modelPluginID="de.fraunhofer.ipa.kinematics"
+    modelName="Xacro" rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container"
+    importerID="org.eclipse.emf.importer.ecore" complianceLevel="5.0" copyrightFields="false"
+    usedGenPackages="../../org.eclipse.emf.ecore/model/Ecore.genmodel#//ecore urdf.genmodel#//urdf"
+    operationReflection="true" importOrganizing="true">
+  <foreignModel>xacro.ecore</foreignModel>
+  <genPackages prefix="Xacro" disposableProviderFactory="true" ecorePackage="xacro.ecore#/">
+    <genClasses ecoreClass="xacro.ecore#//Robot">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute xacro.ecore#//Robot/name"/>
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference xacro.ecore#//Robot/parameter"/>
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference xacro.ecore#//Robot/body"/>
+    </genClasses>
+    <genClasses ecoreClass="xacro.ecore#//Parameter">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute xacro.ecore#//Parameter/Name"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute xacro.ecore#//Parameter/Default"/>
+    </genClasses>
+    <genClasses ecoreClass="xacro.ecore#//Body">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference xacro.ecore#//Body/transmission"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference xacro.ecore#//Body/inertial"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference xacro.ecore#//Body/robot"/>
+    </genClasses>
+  </genPackages>
+</genmodel:GenModel>


### PR DESCRIPTION
This PR implements a basic skeleton for a XACRO (http://wiki.ros.org/xacro) metamodel. The metamodel has to be completed and the backend code for ecore auto-generated. @ipa-hsd I hope it helps as starting point.

![image](https://user-images.githubusercontent.com/650568/137904070-b937a6ba-8f79-4410-96cb-4cd89344cad7.png)
